### PR TITLE
Sample : storage_add_bucket_label

### DIFF
--- a/storage/api/Storage/AddBucketLabel.cs
+++ b/storage/api/Storage/AddBucketLabel.cs
@@ -1,0 +1,25 @@
+﻿using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+
+namespace Storage
+{
+	public class AddBucketLabel
+	{
+		// [START storage_add_bucket_label]
+		public static void AddLabel(string bucketName, string labelKey, string labelValue)
+		{
+			var storage = StorageClient.Create();
+			var bucket = storage.GetBucket(bucketName);
+			if (bucket.Labels == null)
+			{
+				bucket.Labels = new Dictionary<string, string>();
+			}
+			bucket.Labels[labelKey] = labelValue;
+
+			storage.UpdateBucket(bucket);
+			Console.WriteLine($"Updated labels on {bucketName}.");
+		}
+		// [END storage_add_bucket_label]
+	}
+}

--- a/storage/api/Storage/AddBucketLabel.cs
+++ b/storage/api/Storage/AddBucketLabel.cs
@@ -18,7 +18,7 @@ namespace Storage
 			bucket.Labels[labelKey] = labelValue;
 
 			storage.UpdateBucket(bucket);
-			Console.WriteLine($"Updated labels on {bucketName}.");
+			Console.WriteLine($"Updated label {labelKey} wih value {labelValue} on bucket {bucketName}.");
 		}
 		// [END storage_add_bucket_label]
 	}

--- a/storage/api/Storage/Storage.cs
+++ b/storage/api/Storage/Storage.cs
@@ -47,6 +47,7 @@ namespace GoogleCloudSamples
             "  Storage generate-signed-get-url-v4 bucket-name object-name\n" +
             "  Storage generate-signed-put-url-v4 bucket-name object-name\n" +
             "  Storage view-bucket-iam-members bucket-name\n" +
+            "  Storage add-bucket-label bucket-name label-key label-value\n" +
             "  Storage add-bucket-iam-member bucket-name role member\n" +
             "  Storage add-bucket-iam-conditional-binding bucket-name member\n" +
             "                              role member cond-title cond-description cond-expression\n" +
@@ -1622,6 +1623,10 @@ namespace GoogleCloudSamples
                     case "get-uniform-bucket-level-access":
                         if (args.Length < 2 && PrintUsage()) return -1;
                         GetUniformBucketLevelAccess(args[1]);
+                        break;
+
+                    case "add-bucket-label":
+                        AddBucketLabel.AddLabel(args[1], args[2], args[3]);
                         break;
 
                     default:

--- a/storage/api/Storage/Storage.cs
+++ b/storage/api/Storage/Storage.cs
@@ -298,6 +298,7 @@ namespace GoogleCloudSamples
             }
             Console.WriteLine($"Id:\t{bucket.Id}");
             Console.WriteLine($"Kind:\t{bucket.Kind}");
+            Console.WriteLine($"Labels:\t{bucket.Labels}");
             Console.WriteLine($"Lifecycle:\t{bucket.Lifecycle}");
             Console.WriteLine($"Location:\t{bucket.Location}");
             Console.WriteLine($"LocationType:\t{bucket.LocationType}");

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -240,6 +240,26 @@ namespace GoogleCloudSamples
                 Assert.Contains(_bucketName, listed.Stdout);
             });
         }
+        
+        [Fact]
+        public void TestAddBucketLabel()
+        {
+            var labelKey = "text";
+            var labelValue = "example";
+            // Try adding bucket label with above values.
+            var add_label = Run("add-bucket-label", _bucketName, labelKey, labelValue);
+            Assert.Equal(409, add_label.ExitCode);
+
+            // Try getting the metadata of the bucket.  We should find updated label.
+            Eventually(() =>
+            {
+                var bucketMetaData = Run("get-bucket-metadata", _bucketName);
+                AssertSucceeded(bucketMetaData);
+                Assert.Contains(_bucketName, bucketMetaData.Stdout);
+                Assert.Contains(labelKey, bucketMetaData.Stdout);
+                Assert.Contains(labelValue, bucketMetaData.Stdout);
+            });
+        }
 
         [Fact]
         public void TestListObjectsInBucket()

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -248,7 +248,7 @@ namespace GoogleCloudSamples
             var labelValue = "example";
             // Try adding bucket label with above values.
             var add_label = Run("add-bucket-label", _bucketName, labelKey, labelValue);
-            Assert.Equal(409, add_label.ExitCode);
+            AssertSucceeded(add_label);
 
             // Try getting the metadata of the bucket.  We should find updated label.
             Eventually(() =>


### PR DESCRIPTION
Test case might fail
as get-bucket-metadata
prints iDictionary lables and its ToString () might not include the keys / values.