### PR TITLE
Sample : storage_cors_configuration

### DIFF
--- a/storage/api/Storage/ConfigureBucketCors.cs
+++ b/storage/api/Storage/ConfigureBucketCors.cs
@@ -1,0 +1,33 @@
+﻿using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+
+namespace Storage
+{
+	public class ConfigureBucketCors
+	{
+		// [START storage_cors_configuration]
+		public static void ConfigureCors(string bucketName)
+		{
+			var storage = StorageClient.Create();
+			var bucket = storage.GetBucket(bucketName);
+
+			Bucket.CorsData corsData = new Bucket.CorsData();
+			corsData.Origin = new string[] { "*" };
+			corsData.ResponseHeader = new string[] { "Content-Type", "x-goog-resumable" };
+			corsData.Method = new string[] { "PUT", "POST" };
+			corsData.MaxAgeSeconds = 3600; //One Hour
+
+			if (bucket.Cors == null)
+			{
+				bucket.Cors = new List<Bucket.CorsData>();
+			}
+			bucket.Cors.Add(corsData);
+
+			storage.UpdateBucket(bucket);
+			Console.WriteLine($"Cors configured for bucket {bucketName} with Origin {corsData.Origin[0]}, Methods {corsData.Method[0]}.");
+		}
+		// [END storage_cors_configuration]
+	}
+}

--- a/storage/api/Storage/Storage.cs
+++ b/storage/api/Storage/Storage.cs
@@ -39,6 +39,7 @@ namespace GoogleCloudSamples
             "  Storage get-bucket-metadata bucket-name\n" +
             "  Storage make-public bucket-name object-name\n" +
             "  Storage upload [-key encryption-key] bucket-name local-file-path [object-name]\n" +
+            "  Storage configure-cors bucket-name\n" +
             "  Storage copy source-bucket-name source-object-name dest-bucket-name dest-object-name\n" +
             "  Storage move bucket-name source-object-name dest-object-name\n" +
             "  Storage download [-key encryption-key] bucket-name object-name [local-file-path]\n" +
@@ -1622,6 +1623,11 @@ namespace GoogleCloudSamples
                     case "get-uniform-bucket-level-access":
                         if (args.Length < 2 && PrintUsage()) return -1;
                         GetUniformBucketLevelAccess(args[1]);
+                        break;
+
+                    case "configure-cors":
+                        if (args.Length < 2 && PrintUsage()) return -1;
+                        ConfigureBucketCors.ConfigureCors(args[1]);
                         break;
 
                     default:

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -242,6 +242,26 @@ namespace GoogleCloudSamples
         }
 
         [Fact]
+        public void TestConfigureBucketCors()
+        {
+            // Try configuring cors for bucket.
+            var origin = "*";
+            var method = "PUT";
+            var cors_conf = Run("configure-cors", _bucketName);
+            Assert.Equal(409, cors_conf.ExitCode);
+
+            // Try getting the metadata of the bucket.  We should find newly configured cors.
+            Eventually(() =>
+            {
+                var bucketMetaData = Run("get-bucket-metadata", _bucketName);
+                AssertSucceeded(bucketMetaData);
+                Assert.Contains(_bucketName, bucketMetaData.Stdout);
+                Assert.Contains(origin, bucketMetaData.Stdout);
+                Assert.Contains(method, bucketMetaData.Stdout);
+            });
+        }
+
+        [Fact]
         public void TestListObjectsInBucket()
         {
             // Try listing the files.  There should be none.

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -248,7 +248,7 @@ namespace GoogleCloudSamples
             var origin = "*";
             var method = "PUT";
             var cors_conf = Run("configure-cors", _bucketName);
-            Assert.Equal(409, cors_conf.ExitCode);
+            AssertSucceeded(cors_conf);
 
             // Try getting the metadata of the bucket.  We should find newly configured cors.
             Eventually(() =>


### PR DESCRIPTION
Test case might fail
as get-bucket-metadata
prints iList Cors and its ToString () might not include the values in the CorsData elements.